### PR TITLE
Fixing edge case for rolling ops

### DIFF
--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -360,6 +360,9 @@ class RollingOpsManager(Object):
         """Request a lock."""
         try:
             Lock(self).acquire()  # Updates relation data
+            # emit relation changed event in the edge case where aquire does not
+            relation = self.model.get_relation(self.name)
+            self.charm.on[self.name].relation_changed.emit(relation)
         except LockNoRelationError:
             logger.debug("No {} peer relation yet. Delaying rolling op.".format(self.name))
             event.defer()


### PR DESCRIPTION
### Problem
<!-- What problem is this PR trying to solve? -->

In short this solves the issue #2 

In long:
As of now in `rolling_ops.py`, `RollingOpsManager` relies on receiving `RelationChangedEvents` from the `Lock` when changes to the `Lock`’s state occur (ie release, acquire, etc). But if a single unit of `RollingOpsManager` then updates to the relation database do not trigger a `RelationChangedEvent`. (This is a known phenomenon in Juju, where if the current unit makes a change to the relation data bag, the current unit will not receive a `RelationChangedEvent`. )

This is a problem because if `RollingOpsManager` doesn’t receive a `RelationChangedEvent` it will not process the lock or run the callback function, thus leading to an infinite hold on the lock. 

### Solution
<!-- A summary of the solution addressing the above problem -->
To resolve this, we emit a `RelationChangedEvent` after acquiring the lock. The thought process is that if there is only one unit of `RollingOpsManager` then this should emit the expected event. And in the case of multiple events this still leads to idempotent behaviour. In the case of multiple locks the change will lead to 2 calls to `on_relation_changed`, and the behaviour of `relation_changed` is dependent on the the lock status, so calling it one extra time won’t be harmful. Further this will only add one extra call to `_on_relation_changed`, so its impact to runtime is `O(1)` so it shouldn’t affect performance.

### Context
<!-- What is some specialised knowledge relevant to this project/technology -->
As mentioned earlier some specialised knowledge is the phenomenon  in Juju, where if the current unit makes a change to the relation data bag, the current unit will not receive a `RelationChangedEvent`. 

### Release Notes
<!-- A digestable summary of the change in this PR -->
Changes:
- `charm-rolling-ops/lib/charms/rolling_ops/v0/rollingops.py` - `_on_acquire_lock`  emits relation changed after acquiring lock

### Testing
To verify these changes we run the execute the rolling ops code of a single unit, to verify that when there is a single unit the rolling ops is able to acquire the lock and update the code as expected.
